### PR TITLE
[Private] Add hook for missing field resolvers to be called during schema building

### DIFF
--- a/src/main/kotlin/graphql/kickstart/tools/MissingFieldResolverHandler.kt
+++ b/src/main/kotlin/graphql/kickstart/tools/MissingFieldResolverHandler.kt
@@ -1,0 +1,12 @@
+package graphql.kickstart.tools
+
+import graphql.language.FieldDefinition
+import graphql.language.ObjectTypeDefinition
+import graphql.schema.DataFetcher
+
+interface MissingFieldResolverHandler {
+    fun handle(field: FieldDefinition, type: ObjectTypeDefinition,
+                               options: SchemaParserOptions): DataFetcher<Any?> {
+        return options.missingResolverDataFetcher ?: DataFetcher<Any?> { TODO("Schema resolver not implemented") }
+    }
+}

--- a/src/main/kotlin/graphql/kickstart/tools/SchemaClassScanner.kt
+++ b/src/main/kotlin/graphql/kickstart/tools/SchemaClassScanner.kt
@@ -266,7 +266,7 @@ internal class SchemaClassScanner(
 
     private fun scanResolverInfoForPotentialMatches(type: ObjectTypeDefinition, resolverInfo: ResolverInfo) {
         type.getExtendedFieldDefinitions(extensionDefinitions).forEach { field ->
-            val fieldResolver = fieldResolverScanner.findFieldResolver(field, resolverInfo)
+            val fieldResolver = fieldResolverScanner.findFieldResolver(field, type, resolverInfo)
 
             fieldResolversByType.getOrPut(type) { mutableMapOf() }[fieldResolver.field] = fieldResolver
 

--- a/src/main/kotlin/graphql/kickstart/tools/SchemaParserOptions.kt
+++ b/src/main/kotlin/graphql/kickstart/tools/SchemaParserOptions.kt
@@ -5,6 +5,7 @@ import graphql.kickstart.tools.proxy.*
 import graphql.kickstart.tools.relay.RelayConnectionFactory
 import graphql.kickstart.tools.util.JavaType
 import graphql.kickstart.tools.util.ParameterizedTypeImpl
+import graphql.language.FieldDefinition
 import graphql.schema.DataFetcher
 import graphql.schema.DataFetchingEnvironment
 import graphql.schema.visibility.GraphqlFieldVisibility
@@ -23,6 +24,7 @@ data class SchemaParserOptions internal constructor(
     val contextClass: Class<*>?,
     val genericWrappers: List<GenericWrapper>,
     val allowUnimplementedResolvers: Boolean,
+    val missingResolverHandler: MissingFieldResolverHandler,
     val missingResolverDataFetcher: DataFetcher<Any?>?,
     val objectMapperProvider: PerFieldObjectMapperProvider,
     val proxyHandlers: List<ProxyHandler>,
@@ -51,6 +53,7 @@ data class SchemaParserOptions internal constructor(
         private val genericWrappers: MutableList<GenericWrapper> = mutableListOf()
         private var useDefaultGenericWrappers = true
         private var allowUnimplementedResolvers = false
+        private var missingResolverHandler: MissingFieldResolverHandler = object : MissingFieldResolverHandler {}
         private var missingResolverDataFetcher: DataFetcher<Any?>? = null
         private var objectMapperProvider: PerFieldObjectMapperProvider = PerFieldConfiguringObjectMapperProvider()
         private val proxyHandlers: MutableList<ProxyHandler> = mutableListOf(Spring4AopProxyHandler(), GuiceAopProxyHandler(), JavassistProxyHandler(), WeldProxyHandler())
@@ -84,6 +87,10 @@ data class SchemaParserOptions internal constructor(
 
         fun allowUnimplementedResolvers(allowUnimplementedResolvers: Boolean) = this.apply {
             this.allowUnimplementedResolvers = allowUnimplementedResolvers
+        }
+
+        fun missingResolverHandler(missingResolverHandler: MissingFieldResolverHandler) = this.apply {
+            this.missingResolverHandler = missingResolverHandler
         }
 
         fun missingResolverDataFetcher(missingResolverDataFetcher: DataFetcher<Any?>?) = this.apply {
@@ -168,6 +175,7 @@ data class SchemaParserOptions internal constructor(
                 contextClass,
                 wrappers,
                 allowUnimplementedResolvers,
+                missingResolverHandler,
                 missingResolverDataFetcher,
                 objectMapperProvider,
                 proxyHandlers,

--- a/src/main/kotlin/graphql/kickstart/tools/resolver/MissingFieldResolver.kt
+++ b/src/main/kotlin/graphql/kickstart/tools/resolver/MissingFieldResolver.kt
@@ -4,14 +4,16 @@ import graphql.kickstart.tools.MissingResolverInfo
 import graphql.kickstart.tools.SchemaParserOptions
 import graphql.kickstart.tools.TypeClassMatcher
 import graphql.language.FieldDefinition
+import graphql.language.ObjectTypeDefinition
 import graphql.schema.DataFetcher
 
 internal class MissingFieldResolver(
     field: FieldDefinition,
+    val type: ObjectTypeDefinition,
     options: SchemaParserOptions
 ) : FieldResolver(field, FieldResolverScanner.Search(Any::class.java, MissingResolverInfo(), null), options, Any::class.java) {
 
     override fun scanForMatches(): List<TypeClassMatcher.PotentialMatch> = listOf()
-    override fun createDataFetcher(): DataFetcher<*> =
-        options.missingResolverDataFetcher ?: DataFetcher<Any> { TODO("Schema resolver not implemented") }
+    override fun createDataFetcher(): DataFetcher<*> = options.missingResolverHandler.handle(field, type, options)
+
 }

--- a/src/test/kotlin/graphql/kickstart/tools/FieldResolverScannerTest.kt
+++ b/src/test/kotlin/graphql/kickstart/tools/FieldResolverScannerTest.kt
@@ -6,6 +6,7 @@ import graphql.kickstart.tools.resolver.FieldResolverScanner
 import graphql.kickstart.tools.resolver.MethodFieldResolver
 import graphql.kickstart.tools.resolver.PropertyFieldResolver
 import graphql.language.FieldDefinition
+import graphql.language.ObjectTypeDefinition
 import graphql.language.TypeName
 import graphql.relay.Connection
 import graphql.relay.DefaultConnection
@@ -21,8 +22,8 @@ class FieldResolverScannerTest {
     fun `scanner finds fields on multiple root types`() {
         val resolver = RootResolverInfo(listOf(RootQuery1(), RootQuery2()), options)
 
-        val result1 = scanner.findFieldResolver(FieldDefinition("field1", TypeName("String")), resolver)
-        val result2 = scanner.findFieldResolver(FieldDefinition("field2", TypeName("String")), resolver)
+        val result1 = scanner.findFieldResolver(FieldDefinition("field1", TypeName("String")), ObjectTypeDefinition("Type"), resolver)
+        val result2 = scanner.findFieldResolver(FieldDefinition("field2", TypeName("String")), ObjectTypeDefinition("Type"), resolver)
 
         assertNotEquals(result1.search.source, result2.search.source)
     }
@@ -31,22 +32,22 @@ class FieldResolverScannerTest {
     fun `scanner throws exception when more than one resolver method is found`() {
         val resolver = RootResolverInfo(listOf(RootQuery1(), DuplicateQuery()), options)
 
-        scanner.findFieldResolver(FieldDefinition("field1", TypeName("String")), resolver)
+        scanner.findFieldResolver(FieldDefinition("field1", TypeName("String")), ObjectTypeDefinition("Type"), resolver)
     }
 
     @Test(expected = FieldResolverError::class)
     fun `scanner throws exception when no resolver methods are found`() {
         val resolver = RootResolverInfo(listOf(), options)
 
-        scanner.findFieldResolver(FieldDefinition("field1", TypeName("String")), resolver)
+        scanner.findFieldResolver(FieldDefinition("field1", TypeName("String")), ObjectTypeDefinition("Type"), resolver)
     }
 
     @Test
     fun `scanner finds properties when no method is found`() {
         val resolver = RootResolverInfo(listOf(PropertyQuery()), options)
 
-        val name = scanner.findFieldResolver(FieldDefinition("name", TypeName("String")), resolver)
-        val version = scanner.findFieldResolver(FieldDefinition("version", TypeName("Integer")), resolver)
+        val name = scanner.findFieldResolver(FieldDefinition("name", TypeName("String")), ObjectTypeDefinition("Type"), resolver)
+        val version = scanner.findFieldResolver(FieldDefinition("version", TypeName("Integer")), ObjectTypeDefinition("Type"), resolver)
 
         assert(name is PropertyFieldResolver)
         assert(version is PropertyFieldResolver)
@@ -56,7 +57,7 @@ class FieldResolverScannerTest {
     fun `scanner finds generic return type`() {
         val resolver = RootResolverInfo(listOf(GenericQuery()), options)
 
-        val users = scanner.findFieldResolver(FieldDefinition("users", TypeName("UserConnection")), resolver)
+        val users = scanner.findFieldResolver(FieldDefinition("users", TypeName("UserConnection")), ObjectTypeDefinition("Type"), resolver)
 
         assert(users is MethodFieldResolver)
     }
@@ -65,7 +66,7 @@ class FieldResolverScannerTest {
     fun `scanner prefers concrete resolver`() {
         val resolver = DataClassResolverInfo(Kayak::class.java)
 
-        val meta = scanner.findFieldResolver(FieldDefinition("information", TypeName("VehicleInformation")), resolver)
+        val meta = scanner.findFieldResolver(FieldDefinition("information", TypeName("VehicleInformation")), ObjectTypeDefinition("Type"), resolver)
 
         assert(meta is MethodFieldResolver)
         assertEquals((meta as MethodFieldResolver).method.returnType, BoatInformation::class.java)
@@ -75,7 +76,7 @@ class FieldResolverScannerTest {
     fun `scanner finds field resolver method using camelCase for snake_cased field_name`() {
         val resolver = RootResolverInfo(listOf(CamelCaseQuery1()), options)
 
-        val meta = scanner.findFieldResolver(FieldDefinition("hull_type", TypeName("HullType")), resolver)
+        val meta = scanner.findFieldResolver(FieldDefinition("hull_type", TypeName("HullType")), ObjectTypeDefinition("Type"), resolver)
 
         assert(meta is MethodFieldResolver)
         assertEquals((meta as MethodFieldResolver).method.returnType, HullType::class.java)

--- a/src/test/kotlin/graphql/kickstart/tools/MethodFieldResolverDataFetcherTest.kt
+++ b/src/test/kotlin/graphql/kickstart/tools/MethodFieldResolverDataFetcherTest.kt
@@ -5,10 +5,7 @@ import graphql.execution.*
 import graphql.execution.instrumentation.SimpleInstrumentation
 import graphql.kickstart.tools.resolver.FieldResolverError
 import graphql.kickstart.tools.resolver.FieldResolverScanner
-import graphql.language.FieldDefinition
-import graphql.language.InputValueDefinition
-import graphql.language.NonNullType
-import graphql.language.TypeName
+import graphql.language.*
 import graphql.schema.DataFetcher
 import graphql.schema.DataFetchingEnvironment
 import graphql.schema.DataFetchingEnvironmentImpl
@@ -273,12 +270,14 @@ class MethodFieldResolverDataFetcherTest {
             .inputValueDefinitions(arguments)
             .build()
 
+
+
         val resolverInfo = if (resolver is GraphQLQueryResolver) {
             RootResolverInfo(listOf(resolver), options)
         } else {
             NormalResolverInfo(resolver, options)
         }
-        return FieldResolverScanner(options).findFieldResolver(field, resolverInfo).createDataFetcher()
+        return FieldResolverScanner(options).findFieldResolver(field, ObjectTypeDefinition("Type"), resolverInfo).createDataFetcher()
     }
 
     private fun createEnvironment(source: Any = Object(), arguments: Map<String, Any> = emptyMap(), context: Any? = null): DataFetchingEnvironment {

--- a/src/test/kotlin/graphql/kickstart/tools/TypeClassMatcherTest.kt
+++ b/src/test/kotlin/graphql/kickstart/tools/TypeClassMatcherTest.kt
@@ -51,7 +51,7 @@ class TypeClassMatcherTest {
         private val resolver = RootResolverInfo(listOf(QueryMethods()), options)
 
         private fun createPotentialMatch(methodName: String, graphQLType: Type<*>): TypeClassMatcher.PotentialMatch {
-            return scanner.findFieldResolver(FieldDefinition(methodName, graphQLType), resolver)
+            return scanner.findFieldResolver(FieldDefinition(methodName, graphQLType), ObjectTypeDefinition("Type"), resolver)
                 .scanForMatches()
                 .find { it.location == TypeClassMatcher.Location.RETURN_TYPE }!!
         }


### PR DESCRIPTION
<!-- Uncomment one of the following lines as necessary. -->
<!-- Fixes #<ISSUE_NUMBER> -->
<!-- Resolves #<ISSUE_NUMBER> -->

## Checklist
<!-- Change [ ] to [x] to indicate you acknowledge the check. -->
- [ ] Pull requests follows the [contribution guide](https://github.com/graphql-java-kickstart/graphql-java-tools/wiki/Contribution-guide)
- [ ] New or modified functionality is covered by tests

## Description
Adds a hook to allow missing field resolver to be instrumented. This allows folks to possibly log, and track preview fields.

For our project, we use it to work item automation and/or validation of our custom resolver implementation.
